### PR TITLE
Lower dataVolumeClaimSpec storage to 400Mi

### DIFF
--- a/charts/crunchy-postgis/values.yaml
+++ b/charts/crunchy-postgis/values.yaml
@@ -9,7 +9,7 @@ instances:
   name: ha # high availability
   replicas: 2
   dataVolumeClaimSpec:
-    storage: 480Mi
+    storage: 400Mi
     storageClassName: netapp-block-standard
   requests:
     cpu: 1m


### PR DESCRIPTION
Alerts are being triggered when using 100% of allotted storage, so lowering the claim to avoid that.